### PR TITLE
Various QoL improvements over the original

### DIFF
--- a/trades/metrics.py
+++ b/trades/metrics.py
@@ -18,6 +18,19 @@ def get_all_order_prices(order):
     return coin_stats
 
 
+def get_all_order_dates(order):
+    """
+    Takes a dict of all orders and organises the last_price
+    """
+    coin_stats = {}
+    for coin in order:
+        coin_stats[coin] = []
+        for item in order[coin]['orders']:
+            coin_stats[coin].append(float(item['time']))
+
+    return coin_stats
+
+
 def calculate_avg_dca(data):
     """
     Takes a dict of lists cotaining last prices for each coin DCad
@@ -29,6 +42,18 @@ def calculate_avg_dca(data):
         avg_dca[coin] = np.average(avg_dca[coin])
 
     return avg_dca
+
+def calculate_max_time(data):
+    """
+    Takes a dict of lists cotaining last time for each coin DCad
+    And calculates the max DCA time for each coin
+    """
+    max_dca_time = {}
+    for coin in data:
+        max_dca_time[coin] = np.array(data[coin])
+        max_dca_time[coin] = np.amax(max_dca_time[coin])
+
+    return max_dca_time
 
 
 def plot_dca_history(data, average):


### PR DESCRIPTION
When an order fails (error returned by Binance API) the log now correctly reflects this
Order quantity now always rounds up to nearest denomination of a coin allowed on Binance. This means DCA orders of the minimum amount (10 UDST) will no longer fail for falling below the minimum trade amount where the quantity has been rounded down
Bot now uses spot market orders instead of margin orders as in the original
Test trades now use the Binance API test trade request, giving authentic error codes for testing purposes
Instead of using a sleep command for the full duration of the DCA wait period, I've incorporated a check every 15 minutes to see if enough time has passed since last trade. This way the script is crash and reboot resistant. In the original a restart of the script would mean an instant buy of all coins. This method allows you to restart and it will still wait the full duration. Also logs each attempt to clearly show script is still running. If DCA period is less than 15 minutes, the sleep time is reduced to the DCA period
Buys are only logged if order was successfully placed on Binance, ensuring records are accurate. If a buy order failed in the original it would still be logged in the history